### PR TITLE
Fixed compare function in daeIDResolverType.

### DIFF
--- a/dom/src/dae/daeAtomicType.cpp
+++ b/dom/src/dae/daeAtomicType.cpp
@@ -812,7 +812,7 @@ daeInt daeResolverType::compare(daeChar* value1, daeChar* value2) {
 }
 
 daeInt daeIDResolverType::compare(daeChar* value1, daeChar* value2) {
-    return (daeIDRef&)*value1 == (daeIDRef&)*value2;
+    return strcmp(((daeIDRef*)value1)->getID(), ((daeIDRef*)value2)->getID());
 }
 
 


### PR DESCRIPTION
All of the compare functions return 0 for equal and -1 or 1 for not equal depending on which is greater (like strcmp or memcmp). The daeIDResolverType returned a bool which when converted to an int ends up as 0 for not equal and 1 for equal.

For example, when using the daeElement compare function to compare init_from elements it gives the incorrect result.
