### PR TITLE
pkgconfig: fix variable expansion in pkgconfig file

### DIFF
--- a/collada-dom.pc.in
+++ b/collada-dom.pc.in
@@ -2,11 +2,11 @@
 
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@/bin
-libdir=@CMAKE_INSTALL_PREFIX@/lib@LIB_SUFFIX%
+libdir=@CMAKE_INSTALL_PREFIX@/lib@LIB_SUFFIX@
 includedir=@CMAKE_INSTALL_PREFIX@/@COLLADA_DOM_INCLUDE_INSTALL_DIR@
 
 Name: collada-dom
-Description: COLLADA Document Object Model (DOM), 1.4 support=%OPT_COLLADA14%, 1.5 support=%OPT_COLLADA15%
+Description: COLLADA Document Object Model (DOM), 1.4 support=@OPT_COLLADA14@, 1.5 support=@OPT_COLLADA15@
 Version: @COLLADA_DOM_VERSION@
 URL:  http://sourceforge.net/projects/collada-dom
 Libs: -L${libdir} -lcollada-dom@COLLADA_DOM_LIBRARY_SUFFIX@


### PR DESCRIPTION
This is a fix of several typos in the pkgconfig generation file. This was reported by Shawn Starr in the [Red Hat Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1182891).