### PR TITLE
cmake: substitute _PREFIX explicitly during build

### DIFF
--- a/collada_dom-config.cmake.in
+++ b/collada_dom-config.cmake.in
@@ -12,8 +12,7 @@
 # COLLADA_DOM_LIBRARY_DIRS - link directories
 # COLLADA_DOM_LIBRARIES - libraries to link plugins with
 # COLLADA_DOM_Boost_VERSION - the boost version collada-dom was compiled with
-set(_PREFIX @CMAKE_INSTALL_PREFIX@)
-set(COLLADA_DOM_ROOT_DIR "${_PREFIX}")
+set(COLLADA_DOM_ROOT_DIR "@CMAKE_INSTALL_PREFIX@")
 
 if( MSVC )
   # in order to prevent DLL hell, each of the DLLs have to be suffixed with the major version and msvc prefix

--- a/collada_dom-config.cmake.in
+++ b/collada_dom-config.cmake.in
@@ -12,10 +12,8 @@
 # COLLADA_DOM_LIBRARY_DIRS - link directories
 # COLLADA_DOM_LIBRARIES - libraries to link plugins with
 # COLLADA_DOM_Boost_VERSION - the boost version collada-dom was compiled with
-get_filename_component(_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
-get_filename_component(_PREFIX "${_PREFIX}" PATH)
-get_filename_component(_PREFIX "${_PREFIX}" PATH)
-get_filename_component(COLLADA_DOM_ROOT_DIR "${_PREFIX}" PATH)
+set(_PREFIX @CMAKE_INSTALL_PREFIX@)
+set(COLLADA_DOM_ROOT_DIR "${_PREFIX}")
 
 if( MSVC )
   # in order to prevent DLL hell, each of the DLLs have to be suffixed with the major version and msvc prefix


### PR DESCRIPTION
Instead of setting _PREFIX to CMAKE_CURRENT_LIST_FILE, explicitly
substitute _PREFIX with the value of CMAKE_INSTALL_PREFIX during the
build process.

This avoids a bug where COLLADA_DOM_ROOT_DIR was set to '/' if the path
contains '/lib', which results in COLLADA_DOM_INCLUDE_DIRS being
'/include/collada-dom' instead of '/usr/include/collada-dom'.