### PR TITLE
Optimize daeStringTable

### DIFF
--- a/dom/include/dae/daeStringTable.h
+++ b/dom/include/dae/daeStringTable.h
@@ -11,6 +11,9 @@
 #include <dae/daeTypes.h>
 #include <dae/daeMemorySystem.h>
 
+#include <vector>
+#include <string>
+
 /**
  * The @c daeStringTable is a simple string table class to hold a float list of strings
  * without a lot of allocations.
@@ -47,13 +50,10 @@ public: // INTERFACE
 	DLLSPEC void clear();
 
 private: // MEMBERS
-	size_t _stringBufferSize;
-	size_t _stringBufferIndex;
-	daeStringArray _stringBuffersList;
-
-	daeString allocateBuffer();
 
 	daeString _empty;
+
+	std::vector<const char*> vstr;
 };
 
 #endif //__DAE_STRING_TABLE_H__

--- a/dom/src/dae/daeStringTable.cpp
+++ b/dom/src/dae/daeStringTable.cpp
@@ -8,57 +8,25 @@
 
 #include <dae/daeStringTable.h>
 
-daeStringTable::daeStringTable(int stringBufferSize):_stringBufferSize(stringBufferSize), _empty( "" )
+daeStringTable::daeStringTable(int stringBufferSize)
 {
-	_stringBufferIndex = _stringBufferSize;
-	//allocate initial buffer
-	//allocateBuffer();
-}
-
-daeString daeStringTable::allocateBuffer()
-{
-	daeString buf = new daeChar[_stringBufferSize];
-	_stringBuffersList.append(buf);
-	_stringBufferIndex = 0;
-	return buf;
+	_empty = "";
 }
 
 daeString daeStringTable::allocString(daeString string)
 {
 	if ( string == NULL ) return _empty;
 	size_t stringSize = strlen(string) + 1;
-	size_t sizeLeft = _stringBufferSize - _stringBufferIndex;
-	daeString buf;
-	if (sizeLeft < stringSize)
-	{
-		if (stringSize > _stringBufferSize)
-			_stringBufferSize = ((stringSize / _stringBufferSize) + 1) * _stringBufferSize ;
-		buf = allocateBuffer();
-	}
-	else
-	{
-		buf = _stringBuffersList.get((daeInt)_stringBuffersList.getCount()-1);
-	}
-	daeChar *str = (char*)buf + _stringBufferIndex;
-	memcpy(str,string,stringSize);
-	_stringBufferIndex += stringSize;
-
-	int align = sizeof(void*);
-	_stringBufferIndex = (_stringBufferIndex+(align-1)) & (~(align-1));
-
-	return str;
+	char* s = (char*) aligned_alloc(sizeof(void*), stringSize);
+	memcpy(s, string, stringSize);
+	vstr.push_back(s);
+	return s;
 }
 
 void daeStringTable::clear()
 {
-	unsigned int i;
-	for (i=0;i<_stringBuffersList.getCount();i++)
-#if _MSC_VER <= 1200
-		delete [] (char *) _stringBuffersList[i];
-#else
-		delete [] _stringBuffersList[i];
-#endif
-
-	_stringBuffersList.clear();
-	_stringBufferIndex = _stringBufferSize;
+	for (size_t i = 0; i < vstr.size(); ++i) {
+		free((void*) vstr[i]);
+	}
+	vstr.clear();
 }


### PR DESCRIPTION
Remove string pool. Use aligned malloc on individual string instead. It is much faster because the string pool uses daeTArray, and it needs to copy all the strings when the array(vector) expands.