### PR TITLE
Remove call to xmlCleanupParser(), because it is unsafe to call when …

### DIFF
--- a/dom/src/modules/LIBXMLPlugin/daeLIBXMLPlugin.cpp
+++ b/dom/src/modules/LIBXMLPlugin/daeLIBXMLPlugin.cpp
@@ -165,7 +165,9 @@ daeLIBXMLPlugin::~daeLIBXMLPlugin()
         xmlFreeTextWriter( writer );
         writer = NULL;
     }
-    xmlCleanupParser();
+    // according to libxml2 source, xmlCleanupParser can only be called when the application
+    // has no other usage of libxml2, which we cannot guarantee here, so it is unsafe to call
+    // xmlCleanupParser();
 }
 
 daeInt daeLIBXMLPlugin::setOption( daeString option, daeString value )


### PR DESCRIPTION
…we are unsure if others are using libxml2 in the same process.

`daeLIBXMLPlugin` should not have called `xmlCleanupParser()`

```c++
/**
 * xmlCleanupParser:
 *
 * This function name is somewhat misleading. It does not clean up
 * parser state, it cleans up memory allocated by the library itself.
 * It is a cleanup function for the XML library. It tries to reclaim all
 * related global memory allocated for the library processing.
 * It doesn't deallocate any document related memory. One should
 * call xmlCleanupParser() only when the process has finished using
 * the library and all XML/HTML documents built with it.
 * See also xmlInitParser() which has the opposite function of preparing
 * the library for operations.
 *
 * WARNING: if your application is multithreaded or has plugin support
 *          calling this may crash the application if another thread or
 *          a plugin is still using libxml2. It's sometimes very hard to
 *          guess if libxml2 is in use in the application, some libraries
 *          or plugins may use it without notice. In case of doubt abstain
 *          from calling this function or do it just before calling exit()
 *          to avoid leak reports from valgrind !
 */

void
xmlCleanupParser(void)
```

I think the problem is in openrave we use libxml outside of DAE as well, like all the other xml readers, like `ParseXMLData`.

According to the libxml source, `xmlCleanupParser` should not have been called.

```c++
daeLIBXMLPlugin::~daeLIBXMLPlugin()
{
    if( !writer ) {
        xmlFreeTextWriter( writer );
        writer = NULL;
    }
    xmlCleanupParser();
}
```

Right now we call it on every dae read/write.

The implementation of `xmlCleanupParser` also suggests that it is not safe to call from multiple threads, where as `xmlInitParser` has mutex protection.