### PR TITLE
Silence warnings

### DIFF
--- a/dom/include/dae.h
+++ b/dom/include/dae.h
@@ -290,7 +290,7 @@ private:
     daeSidRefCache sidRefCache;
     daeString COLLADA_VERSION, COLLADA_NAMESPACE; // dynamic
 
-    std::auto_ptr<charEncoding> localCharEncoding;
+    std::unique_ptr<charEncoding> localCharEncoding;
     static charEncoding globalCharEncoding;
 };
 

--- a/dom/include/dae/daeErrorHandler.h
+++ b/dom/include/dae/daeErrorHandler.h
@@ -55,7 +55,7 @@ public:
 
 private:
 	static daeErrorHandler *_instance;
-	static std::auto_ptr<daeErrorHandler> _defaultInstance;
+	static std::unique_ptr<daeErrorHandler> _defaultInstance;
 };
 
 #endif

--- a/dom/include/dae/daeWin32Platform.h
+++ b/dom/include/dae/daeWin32Platform.h
@@ -38,7 +38,7 @@ typedef int intptr_t;
 
 // GCC doesn't understand "#pragma warning"
 #ifdef _MSC_VER
-// class 'std::auto_ptr<_Ty>' needs to have dll-interface to be used by clients of class 'daeErrorHandler'
+// class 'std::unique_ptr<_Ty>' needs to have dll-interface to be used by clients of class 'daeErrorHandler'
 #pragma warning(disable: 4251)
 // warning C4100: 'profile' : unreferenced formal parameter
 #pragma warning(disable: 4100)

--- a/dom/src/dae/daeDom.cpp
+++ b/dom/src/dae/daeDom.cpp
@@ -111,7 +111,7 @@ daeInt getDomAnyID(DAE& dae)
         return ColladaDOM141::domAny::ID();
     }
 #endif
-    return NULL;
+    return 0;
 }
 
 daeInt getDomSourceID(DAE& dae)
@@ -126,7 +126,7 @@ daeInt getDomSourceID(DAE& dae)
         return ColladaDOM141::domSource::ID();
     }
 #endif
-    return NULL;
+    return 0;
 }
 
 daeInt getDomCOLLADAID(const char* specversion)
@@ -141,7 +141,7 @@ daeInt getDomCOLLADAID(const char* specversion)
         return ColladaDOM141::domCOLLADA::ID();
     }
 #endif
-    return NULL;
+    return 0;
 }
 
 void copyElementAny(daeElementRef dstAny, daeElement* srcAny)

--- a/dom/src/dae/daeErrorHandler.cpp
+++ b/dom/src/dae/daeErrorHandler.cpp
@@ -10,7 +10,7 @@
 #include <modules/stdErrPlugin.h>
 
 daeErrorHandler *daeErrorHandler::_instance = NULL;
-std::auto_ptr<daeErrorHandler> daeErrorHandler::_defaultInstance(new stdErrPlugin);
+std::unique_ptr<daeErrorHandler> daeErrorHandler::_defaultInstance(new stdErrPlugin);
 
 daeErrorHandler::daeErrorHandler() {
 }

--- a/dom/test/1.4/domTest.cpp
+++ b/dom/test/1.4/domTest.cpp
@@ -368,7 +368,7 @@ DefineTest(tinyXmlLoad) {
     // saved document, and make sure the results are the same.
     DAE dae;
     CheckResult(dae.open(seymourOrig));
-    auto_ptr<daeTinyXMLPlugin> tinyXmlPlugin(new daeTinyXMLPlugin);
+    unique_ptr<daeTinyXMLPlugin> tinyXmlPlugin(new daeTinyXMLPlugin);
     dae.setIOPlugin(tinyXmlPlugin.get());
     CheckResult(dae.writeTo(seymourOrig, seymourTinyXml));
     CheckResult(dae.open(seymourTinyXml));

--- a/dom/test/1.5/domTest.cpp
+++ b/dom/test/1.5/domTest.cpp
@@ -371,7 +371,7 @@ DefineTest(tinyXmlLoad) {
     // saved document, and make sure the results are the same.
     DAE dae;
     CheckResult(dae.open(seymourOrig));
-    auto_ptr<daeTinyXMLPlugin> tinyXmlPlugin(new daeTinyXMLPlugin);
+    unique_ptr<daeTinyXMLPlugin> tinyXmlPlugin(new daeTinyXMLPlugin);
     dae.setIOPlugin(tinyXmlPlugin.get());
     CheckResult(dae.writeTo(seymourOrig, seymourTinyXml));
     CheckResult(dae.open(seymourTinyXml));


### PR DESCRIPTION
- Silence warnings related to the deprecation of `auto_ptr` (removed in C++17)
- Silence warnings related to casting of `NULL` to int (-Wconversion-null), make intent to return 0 clear.